### PR TITLE
Publish images to our registry instead of DockerHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,9 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v1.10.0
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        registry: registry.staffbase.com
+        username: ${{ secrets.DOCKER_USER }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Release
       uses: goreleaser/goreleaser-action@v2.6.1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,10 +15,10 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - "staffbace/yamllint-action:{{ .Tag }}"
-      - "staffbace/yamllint-action:{{ .Major }}"
-      - "staffbace/yamllint-action:{{ .Major }}.{{ .Minor }}"
-      - "staffbace/yamllint-action:latest"
+      - "registry.staffbase.com/public/yamllint-action:{{ .Tag }}"
+      - "registry.staffbase.com/public/yamllint-action:{{ .Major }}"
+      - "registry.staffbase.com/public/yamllint-action:{{ .Major }}.{{ .Minor }}"
+      - "registry.staffbase.com/public/yamllint-action:latest"
     extra_files:
     - entrypoint.sh
 


### PR DESCRIPTION
DockerHub org is not in a good shape (ownership is unclear), so let's use Harbor for now.