### PR TITLE
added quotes to TARGET_PATH variable

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheckcla' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
         uses: cla-assistant/github-action@v2.1.3-beta
         env: 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -6,8 +6,6 @@ name: "CLA Assistant"
 on:
   pull_request:
     types: [opened,closed,synchronize]
-  pull_request_review_comment:
-    types: [created]
   issue_comment:
     types: [created]
     

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -21,7 +21,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.OSS_CONTRIBUTOR_LICENSE_AGREEMENT }}
         with: 
           path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/Staffbase/yamllin-action/blob/master/CLA.md'
+          path-to-document: 'https://github.com/Staffbase/yamllint-action/blob/master/CLA.md'
           # branch should not be protected
           branch: 'signatures'
           allowlist: 0x46616c6b,axdotl,kaitimmer,ricoberger,bot*

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,10 +4,12 @@
 
 name: "CLA Assistant"
 on:
-  pull_request_review_comment:
-    types: [created]
   pull_request:
     types: [opened,closed,synchronize]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
     
 jobs:
   CLAssistant:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,4 +13,4 @@
 
 set -e
 
-yamllint -f parsable ${TARGET_PATH} | /yamllint-action
+yamllint -f parsable "${TARGET_PATH}" | /yamllint-action


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

<!-- Please describe your pull request -->

* fixes cla link
* fixes variable without qoutes

```
shellcheck entrypoint.sh 

In test.sh line 16:
yamllint -f parsable ${TARGET_PATH} | /yamllint-action
                     ^------------^ SC2086: Double quote to prevent globbing and word splitting.

```

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Review the [Contributing Guideline](https://github.com/Staffbase/yamllint-action/blob/master/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
