### PR TITLE
Change owner from 'diablo' to 'product-core-infra'

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @Staffbase/diablo
+*       @Staffbase/product-core-infra

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -11,5 +11,5 @@ metadata:
     - github-actions
 spec:
   type: service
-  owner: diablo
+  owner: product-core-infra
   lifecycle: production


### PR DESCRIPTION
### Type of Change

<!-- Select the type of your PR -->

- [ ] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

This pull request updates team ownership information to reflect the current responsible team for the codebase. The changes ensure that both the code ownership and service metadata are aligned with the correct team.

Ownership updates:

* Changed the default code owner in `.github/CODEOWNERS` from `@Staffbase/diablo` to `@Staffbase/product-core-infra`.
* Updated the `owner` field in `catalog-info.yaml` from `diablo` to `product-core-infra`.

### Checklist

<!-- Please go through this checklist and make sure all applicable tasks have been done -->

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Review the [Contributing Guideline](https://github.com/Staffbase/yamllint-action/blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
