### PR TITLE
ci: replace app id with client id

### DIFF
--- a/.github/workflows/autodev.yaml
+++ b/.github/workflows/autodev.yaml
@@ -13,5 +13,5 @@ jobs:
     with:
       labels: true
     secrets:
-      app_id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
+      client_id: ${{ vars.STAFFBASE_ACTIONS_CLIENT_ID }}
       private_key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,5 +10,5 @@ jobs:
   release:
     uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v15.1.1
     secrets:
-      app_id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
+      client_id: ${{ vars.STAFFBASE_ACTIONS_CLIENT_ID }}
       private_key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}


### PR DESCRIPTION
### Type of Change

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

Replace the `app_id` field with `client_id` in all GitHub Action workflows,
becase the new versions of th GitHub Action require `client_id` instead of
`app_id`.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Review the
      [Contributing Guideline](https://github.com/Staffbase/yamllint-action/blob/main/CONTRIBUTING.md)
      and sign CLA
- [ ] Reference relevant issue(s) and close them after merging
